### PR TITLE
bugfix: fix string length

### DIFF
--- a/samples/demo_guix_thermostat/demo_guix_thermostat.c
+++ b/samples/demo_guix_thermostat/demo_guix_thermostat.c
@@ -122,7 +122,7 @@ GX_STRING string;
 
     gx_utility_ltoa(i_temperature, str_value, 10);
     string.gx_string_ptr = str_value;
-    string.gx_string_length = sizeof(str_value) - 1;
+    string.gx_string_length = GX_STRLEN(str_value);
     gx_prompt_text_set_ext(prompt, &string);
 }
 


### PR DESCRIPTION
1、此处字符串长度最大为 sizeof(str_value)-1，实际比这个更小，错误的长度导致 gx_prompt_text_set_ext(prompt,&string)函数报错